### PR TITLE
Added S3 file Controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
 		    <artifactId>auth</artifactId>
 		    <version>2.20.0</version>
 		</dependency>
+		
+		<dependency>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-java-sdk-s3</artifactId>
+    <version>1.12.696</version> <!-- You can use a newer version if needed -->
+</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/techeazy/aws/batch2/restcontroller/S3FileController.java
+++ b/src/main/java/com/techeazy/aws/batch2/restcontroller/S3FileController.java
@@ -1,0 +1,47 @@
+package com.techeazy.aws.batch2.restcontroller;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/files")
+public class S3FileController {
+
+    @Autowired
+    private AmazonS3 amazonS3;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    @GetMapping("/{userName}")
+    public ResponseEntity<List<String>> listFiles(@PathVariable String userName) {
+        String prefix = "users/" + userName + "/"; // e.g., users/john/
+
+        ListObjectsV2Request req = new ListObjectsV2Request()
+                .withBucketName(bucketName)
+                .withPrefix(prefix);
+
+        ListObjectsV2Result result = amazonS3.listObjectsV2(req);
+
+        List<String> filenames = new ArrayList<>();
+        for (S3ObjectSummary summary : result.getObjectSummaries()) {
+            String key = summary.getKey();
+            String fileName = key.replace(prefix, ""); // Remove the user folder path
+            if (!fileName.isEmpty()) {
+                filenames.add(fileName);
+            }
+        }
+
+        return ResponseEntity.ok(filenames);
+    }
+}


### PR DESCRIPTION
Created a new REST controller (`FileController`) to handle GET requests for fetching files from AWS S3.
The `getUserFiles` endpoint accepts a `userName` parameter and returns a list of filenames stored in the S3 bucket associated with that user.

Note : 
AWS credentials have not been provided in this PR. Please ensure you configure your AWS credentials.